### PR TITLE
スキルセクションのリンクの当たり判定を修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -65,4 +65,5 @@ a {
   color: inherit;
   height: 100%;
   width: 100%;
+  display: inline-block;
 }


### PR DESCRIPTION
トップページのスキルページへのリンクのサイズが大きすぎたので子要素に合わせるよう修正