### PR TITLE
トップページのaタグのサイズ修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -68,7 +68,7 @@ a {
   display: inline-block;
 }
 
-.dashboard > a {
+.dashboard-link {
   height: min-content;
   width: auto;
 }

--- a/src/pages/TopPage.tsx
+++ b/src/pages/TopPage.tsx
@@ -30,7 +30,7 @@ const TopPage: React.FC = () => {
         <About />
         <Projects />
       </div>
-      <Link to="/skills">
+      <Link to="/skills" className="dashboard-link">
         <motion.div
           ref={skillSectionRef}
           className="section"


### PR DESCRIPTION
dashboardクラス直下のaタグのみ個別でサイズ指定を行うことでトップページのスタイル崩れを修正